### PR TITLE
Allow a ProxMox target node map as input

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_record" "worker" {
-  count   = var.worker_count
+  count   = length(local.worker_list)
   zone_id = var.dns_zone_id
   name    = local.worker_list[count.index].hostname
   value   = local.worker_list[count.index].ip

--- a/variables.tf
+++ b/variables.tf
@@ -38,9 +38,35 @@ variable "vlan" {
   description = "The network vlan ID"
 }
 
-variable "worker_count" {
-  description = "Number of vm's to create for worker nodes"
+# proxmox_node_map is the map of the nodes to be deployed accross targets.
+# An exampe configuration would be:
+# variable "proxmox_node_map" = [
+#   {
+#     proxmox-0 = {
+#       master_count = 1
+#       worker_count = 3
+#     }
+#   },
+#   {
+#     proxmox-1 = {
+#       worker_count = 9
+#     }
+#   }
+# ]
+variable "proxmox_node_map" {
+  description = "A list of ProxMox target nodes and the number of noder per type (cfssl, etcd, master, worker) to deploy on each"
+
+  type = list(map(object({
+    cfssl_count  = optional(number, 0)
+    etcd_count   = optional(number, 0)
+    master_count = optional(number, 0)
+    worker_count = optional(number, 0)
+  })))
+
 }
+//variable "worker_count" {
+//  description = "Number of vm's to create for worker nodes"
+//}
 
 variable "worker_subnet_cidr" {
   description = "Range for assigning worker IP addresses"


### PR DESCRIPTION
So we can pass a number of proxmox target nodes and a number of machine types we can deploy per node.