### PR TITLE
Fixes regarding etcd and cfssl configuration

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -1,5 +1,5 @@
 resource "matchbox_profile" "cfssl" {
-  name   = "cfssl"
+  name   = "cfssl-pve"
   kernel = var.flatcar_kernel_address
   initrd = var.flatcar_initrd_addresses
   args = [
@@ -13,7 +13,7 @@ resource "matchbox_profile" "cfssl" {
 }
 
 resource "matchbox_group" "cfssl" {
-  name    = "cfssl"
+  name    = "cfssl-pve"
   profile = matchbox_profile.cfssl.name
 
   selector = {

--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,22 @@
+resource "cloudflare_record" "cfssl" {
+  zone_id = var.dns_zone_id
+  name    = "cfssl"
+  content = var.cfssl_instance.ip_address
+  type    = "A"
+  ttl     = 120
+}
+
+resource "cloudflare_record" "etcd" {
+  count   = length(var.etcd_members)
+  zone_id = var.dns_zone_id
+  name    = "etcd-${count.index}"
+  content = cidrhost(var.etcd_subnet_cidr, count.index)
+  type    = "A"
+  ttl     = 120
+}
+
 resource "cloudflare_record" "worker" {
   count   = length(var.worker_instance_list)
-  zone_id = var.dns_zone_id
   name    = local.worker_hostname_list[count.index]
   content = var.worker_instance_list[count.index].ip_address
   type    = "A"

--- a/etcd.tf
+++ b/etcd.tf
@@ -1,6 +1,6 @@
 resource "matchbox_profile" "etcd" {
   count  = length(var.etcd_instance_list)
-  name   = local.etcd_hostname_list[count.index]
+  name   = "etcd-pve-${count.index}"
   kernel = var.flatcar_kernel_address
   initrd = var.flatcar_initrd_addresses
   args = [
@@ -15,7 +15,7 @@ resource "matchbox_profile" "etcd" {
 
 resource "matchbox_group" "etcd" {
   count = length(var.etcd_instance_list)
-  name  = local.etcd_hostname_list[count.index]
+  name  = "etcd-pve-${count.index}"
 
   profile = matchbox_profile.etcd[count.index].name
 
@@ -104,7 +104,7 @@ variable "etcd_data_volume_id" {
 
 resource "proxmox_vm_qemu" "etcd" {
   count       = length(var.etcd_instance_list)
-  name        = local.etcd_hostname_list[count.index]
+  name        = "etcd-${count.index}"
   target_node = var.etcd_instance_list[count.index].pve_host
   desc        = "ETCD node"
   pxe         = true

--- a/variables.tf
+++ b/variables.tf
@@ -160,9 +160,6 @@ variable "cluster_subnet" {
 }
 
 locals {
-  # ETCD hostnames are also calculated the same way under our Ansible
-  # configuration for DHCP:
-  etcd_hostname_list = [for etcd in var.etcd_instance_list : "etcd-${substr(sha256(etcd.mac_address), 0, 6)}"]
   # Worker hostnames are also calculated the same way under our Ansible
   # configuration for DHCP:
   # https://github.com/utilitywarehouse/sys-ansible-k8s-on-prem/blob/master/roles/dhcp/templates/dhcp.conf.tmpl


### PR DESCRIPTION
- Suffix matchbox resources so that they do not clash with existing ones
- Move DNS record creation next to instances
- Remove generated string suffix and use numbering for etcd members