### PR TITLE
Do not tag packets with VLAN on VMs' network interfaces

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -122,6 +122,5 @@ resource "proxmox_vm_qemu" "cfssl" {
     macaddr = var.cfssl_instance.mac_address
     model   = "virtio"
     mtu     = 9000
-    tag     = var.vlan
   }
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -137,6 +137,5 @@ resource "proxmox_vm_qemu" "etcd" {
     macaddr = var.etcd_instance_list[count.index].mac_address
     model   = "virtio"
     mtu     = 9000
-    tag     = var.vlan
   }
 }

--- a/masters.tf
+++ b/masters.tf
@@ -89,6 +89,5 @@ resource "proxmox_vm_qemu" "master" {
     macaddr = var.master_instance_list[count.index].mac_address
     model   = "virtio"
     mtu     = 9000
-    tag     = var.vlan
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,10 +30,6 @@ variable "flatcar_initrd_addresses" {
   ]
 }
 
-variable "vlan" {
-  description = "The network vlan ID"
-}
-
 variable "cfssl_instance" {
   type = object({
     ip_address  = string

--- a/workers.tf
+++ b/workers.tf
@@ -92,6 +92,5 @@ resource "proxmox_vm_qemu" "worker" {
     macaddr = var.worker_instance_list[count.index].mac_address
     model   = "virtio"
     mtu     = 9000
-    tag     = var.vlan
   }
 }


### PR DESCRIPTION
Since we are tagging Proxmox ports on a native VLAN, tagging packets
again with the VLAN id will cause them to be dropped on our switches.
This also simplifies the VMs configuration and makes one less different
input variable across environments