### PR TITLE
Split hosts into 3 zones instead of one per hosts

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -35,7 +35,7 @@ data "ignition_file" "master_kubelet_dropin" {
   content {
     content = templatefile("${path.module}/resources/kubelet-dropin.conf",
       {
-        labels = "role=master,topology.kubernetes.io/zone=${var.master_instance_list[count.index].pve_host}"
+        labels = "role=master,topology.kubernetes.io/zone=${var.zone_mapping[var.master_instance_list[count.index].pve_host]}"
       }
     )
   }

--- a/variables.tf
+++ b/variables.tf
@@ -193,6 +193,26 @@ variable "cluster_subnet" {
   description = "Cluster ip subnet"
 }
 
+variable "zone_mapping" {
+  type = map(string)
+  description = "How to map VMs deployed in pve hosts to Kubernetes topology zones"
+
+  default = {
+    "pve-00" = "ld7-a"
+    "pve-01" = "ld7-b"
+    "pve-02" = "ld7-c"
+    "pve-03" = "ld7-a"
+    "pve-04" = "ld7-b"
+    "pve-05" = "ld7-c"
+    "pve-06" = "ld7-a"
+    "pve-07" = "ld7-b"
+    "pve-08" = "ld7-c"
+    "pve-09" = "ld7-a"
+    "pve-10" = "ld7-b"
+    "pve-11" = "ld7-c"
+  }
+}
+
 locals {
   # Mater hostnames are also calculated the same way under our Ansible
   # configuration for DHCP:

--- a/workers.tf
+++ b/workers.tf
@@ -35,7 +35,7 @@ data "ignition_file" "worker_kubelet_dropin" {
   content {
     content = templatefile("${path.module}/resources/kubelet-dropin.conf",
       {
-        labels = "role=worker,topology.kubernetes.io/zone=${var.worker_instance_list[count.index].pve_host}"
+        labels = "role=worker,topology.kubernetes.io/zone=${var.zone_mapping[var.worker_instance_list[count.index].pve_host]}"
       }
     )
   }


### PR DESCRIPTION
This plays nicer with things like kube-proxy, where we are limitted to 8 zones for topology aware routing.