### PR TITLE
Fix deprecated 'desc' argument in proxmox_vm_qemu resources

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -99,7 +99,7 @@ resource "proxmox_vm_qemu" "cfssl" {
   count       = var.cfssl_instance == null ? 0 : 1
   name        = "cfssl"
   target_node = var.cfssl_instance.pve_host
-  desc        = "CFSSL node"
+  description = "CFSSL node"
   pxe         = true
   boot        = "order=net0"
   cpu {

--- a/etcd.tf
+++ b/etcd.tf
@@ -103,7 +103,7 @@ resource "proxmox_vm_qemu" "etcd" {
   count       = length(var.etcd_instance_list)
   name        = "etcd-${count.index}"
   target_node = var.etcd_instance_list[count.index].pve_host
-  desc        = "ETCD node"
+  description = "ETCD node"
   pxe         = true
   boot        = "order=net0"
   cpu {

--- a/masters.tf
+++ b/masters.tf
@@ -61,7 +61,7 @@ resource "proxmox_vm_qemu" "master" {
   count       = length(var.master_instance_list)
   name        = local.master_hostname_list[count.index]
   target_node = var.master_instance_list[count.index].pve_host
-  desc        = "Worker node"
+  description = "Master node"
   pxe         = true
   boot        = "order=net0"
   cpu {

--- a/workers.tf
+++ b/workers.tf
@@ -64,7 +64,7 @@ resource "proxmox_vm_qemu" "worker" {
   count       = length(var.worker_instance_list)
   name        = local.worker_hostname_list[count.index]
   target_node = var.worker_instance_list[count.index].pve_host
-  desc        = "Worker node"
+  description = "Worker node"
   pxe         = true
   boot        = "order=net0"
   cpu {


### PR DESCRIPTION
Replace deprecated 'desc' with 'description' in all proxmox VM resources:
- cfssl.tf: Update CFSSL node description
- etcd.tf: Update ETCD node description
- masters.tf: Update master node description (also fixes incorrect 'Worker node' label)
- workers.tf: Update worker node description

Resolves Terraform deprecation warnings about using 'desc' instead of 'description'.
